### PR TITLE
fix(Malloc): avoid RuntimeHelpers.InitializeArray in transcoded entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@
 mandelbrot.png
 result.png
 newton.png
+lena-sobel.bmp
+strategy_heatmap.png
+# machine-local package feed override
+/nuget.config
 *.pdb
 bin
 *.gguf

--- a/src/1.Simple/Malloc/Program.cs
+++ b/src/1.Simple/Malloc/Program.cs
@@ -31,18 +31,9 @@ namespace Malloc
         [EntryPoint]
         public static void test([Out] double[] dest, [In] double[] src, int N)
         {
-            double[] stencil =
-            [
-                -4.0,
-                -3.0,
-                -2.0,
-                -1.0,
-                0.0,
-                1.0,
-                2.0,
-                3.0,
-                4.0,
-            ];
+            double[] stencil = new double[9];
+            for(int i = 0; i < 9; ++i) { stencil[i] = i - 4.0; }
+
             for (int k = 4 + threadIdx.x + blockIdx.x * blockDim.x; k < N - 4; k += blockDim.x * gridDim.x)
             {
                 dest[k] = apply(stencil, src, k);


### PR DESCRIPTION
## What

Two changes:

1. **Fix the Malloc sample** (`src/1.Simple/Malloc/Program.cs`). The stencil was declared with a collection-expression literal (`double[] stencil = [ -4.0, ... 4.0 ];`), which the C# compiler lowers to a `RuntimeHelpers.InitializeArray` call over a static data blob. The Hybridizer transcoder has no intrinsic for `InitializeArray` and aborts codegen for the entry point (`0X60AC : Cannot get IL for method InitializeArray`), so no kernel wrapper is emitted and the sample fails at runtime with `EntryPointNotFoundException`. Filling the stencil element-by-element (`for (i...) stencil[i] = i - 4.0;`) transcodes cleanly and the sample runs.

2. **Cleanup**: gitignore generated sample outputs (`lena-sobel.bmp`, `strategy_heatmap.png`) and the machine-local `nuget.config` feed override that were showing as untracked.

## Verification

Built and ran the Malloc sample locally; it transcodes and executes without the `EntryPointNotFoundException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)